### PR TITLE
refactor Dependency Configurations

### DIFF
--- a/src/main/kotlin/data/DevPubConfigurationsContainer.kt
+++ b/src/main/kotlin/data/DevPubConfigurationsContainer.kt
@@ -5,9 +5,9 @@ import dev.adamko.gradle.dev_publish.DevPublishPlugin.Companion.DEV_PUB__PUBLICA
 import dev.adamko.gradle.dev_publish.DevPublishPlugin.Companion.DEV_PUB__PUBLICATION_OUTGOING
 import dev.adamko.gradle.dev_publish.data.DevPubConfigurationsContainer.Attributes.Companion.DEV_PUB_USAGE
 import dev.adamko.gradle.dev_publish.internal.DevPublishInternalApi
-import dev.adamko.gradle.dev_publish.utils.asConsumer
-import dev.adamko.gradle.dev_publish.utils.asProvider
-import dev.adamko.gradle.dev_publish.utils.forDependencies
+import dev.adamko.gradle.dev_publish.utils.consumable
+import dev.adamko.gradle.dev_publish.utils.declarable
+import dev.adamko.gradle.dev_publish.utils.resolvable
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
@@ -44,14 +44,13 @@ abstract class DevPubConfigurationsContainer @Inject constructor(
   private fun ConfigurationContainer.registerPublicationsDependencies(): NamedDomainObjectProvider<Configuration> =
     register(DEV_PUB__PUBLICATION_DEPENDENCIES) {
       description = "Declare dependencies on test Maven Publications"
-      forDependencies()
-      attributes { attribute(DEV_PUB_USAGE, devPubAttributes.mavenRepoUsage) }
+      declarable()
     }
 
   private fun ConfigurationContainer.registerPublicationsConsumer(): NamedDomainObjectProvider<Configuration> =
     register(DEV_PUB__PUBLICATION_INCOMING) {
       description = "Resolve test Maven Publications"
-      asConsumer()
+      resolvable()
       attributes { attribute(DEV_PUB_USAGE, devPubAttributes.mavenRepoUsage) }
       extendsFrom(testMavenPublicationDependencies.get())
     }
@@ -59,7 +58,7 @@ abstract class DevPubConfigurationsContainer @Inject constructor(
   private fun ConfigurationContainer.registerPublicationsProvider(): NamedDomainObjectProvider<Configuration> =
     register(DEV_PUB__PUBLICATION_OUTGOING) {
       description = "Provide test Maven Publications"
-      asProvider()
+      consumable()
       attributes { attribute(DEV_PUB_USAGE, devPubAttributes.mavenRepoUsage) }
       extendsFrom(testMavenPublicationDependencies.get())
     }

--- a/src/main/kotlin/utils/gradleUtils.kt
+++ b/src/main/kotlin/utils/gradleUtils.kt
@@ -1,7 +1,32 @@
 package dev.adamko.gradle.dev_publish.utils
 
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.RelativePath
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.util.GradleVersion
+
+
+/**
+ * Mark this [Configuration] as one that should be used to declare dependencies in
+ * [Project.dependencies] block.
+ *
+ * Declarable Configurations should be extended by [resolvable] and [consumable] Configurations.
+ *
+ * ```
+ * isCanBeResolved = false
+ * isCanBeConsumed = false
+ * isCanBeDeclared = true
+ * ```
+ */
+internal fun Configuration.declarable(
+  visible: Boolean = false,
+) {
+  isCanBeResolved = false
+  isCanBeConsumed = false
+  canBeDeclared = true
+  isVisible = visible
+}
 
 
 /**
@@ -13,52 +38,71 @@ import org.gradle.api.file.RelativePath
  * isCanBeDeclared = false
  * ```
  */
-internal fun Configuration.asProvider(
-  visible: Boolean = true
+internal fun Configuration.consumable(
+  visible: Boolean = true,
 ) {
   isCanBeResolved = false
   isCanBeConsumed = true
-  isCanBeDeclared = false
+  canBeDeclared = false
   isVisible = visible
 }
 
 
 /**
- * Mark this [Configuration] as one that will fetch artifacts (also known as 'resolving').
+ * Mark this [Configuration] as one that will consume (also known as 'resolving') artifacts from declared dependencies
  *
  * ```
  * isCanBeResolved = true
  * isCanBeConsumed = false
  * isCanBeDeclared = false
  * ```
- * */
-internal fun Configuration.asConsumer(
-  visible: Boolean = false
+ */
+internal fun Configuration.resolvable(
+  visible: Boolean = false,
 ) {
   isCanBeResolved = true
   isCanBeConsumed = false
-  isCanBeDeclared = false
+  canBeDeclared = false
   isVisible = visible
 }
 
 
 /**
- * Mark this [Configuration] for declaring dependencies in the `dependencies {}` block.
+ * Enable/disable [Configuration.isCanBeDeclared] only if it is supported by the
+ * [CurrentGradleVersion]
  *
- * ```
- * isCanBeResolved = false
- * isCanBeConsumed = false
- * isCanBeDeclared = true
- * ```
- * */
-internal fun Configuration.forDependencies(
-  visible: Boolean = false
-) {
-  isCanBeResolved = false
-  isCanBeConsumed = false
-  isCanBeDeclared = true
-  isVisible = visible
-}
+ * This function should be removed when the minimal supported Gradle version is 8.2.
+ */
+private var Configuration.canBeDeclared: Boolean
+  get() {
+    return if (configurationIsCanBeDeclaredEnabled) {
+      @Suppress("UnstableApiUsage")
+      isCanBeDeclared
+    } else {
+      false
+    }
+  }
+  set(value) {
+    if (configurationIsCanBeDeclaredEnabled) {
+      @Suppress("UnstableApiUsage")
+      isCanBeDeclared = value
+    } else {
+      // do nothing
+    }
+  }
+
+/** `true` if [Configuration.isCanBeDeclared] is valid for the current Gradle version. */
+private val configurationIsCanBeDeclaredEnabled: Boolean = CurrentGradleVersion >= "8.2"
+
+
+/** Shortcut for [GradleVersion.current] */
+internal val CurrentGradleVersion: GradleVersion
+  get() = GradleVersion.current()
+
+
+/** Compare a [GradleVersion] to a [version]. */
+internal operator fun GradleVersion.compareTo(version: String): Int =
+  compareTo(GradleVersion.version(version))
 
 
 /** Drop the first [count] directories from the [RelativePath] */


### PR DESCRIPTION
- update declarable/resolvable/consumable shortcuts
- Gradle version guard `isCanBeDeclared`
- remove attributes from declarable Configuration (which triggers a warning in Gradle Build Scans)