### PR TITLE
Update Configuration Attributes

### DIFF
--- a/src/main/kotlin/data/DevPubAttributes.kt
+++ b/src/main/kotlin/data/DevPubAttributes.kt
@@ -2,9 +2,9 @@ package dev.adamko.gradle.dev_publish.data
 
 import dev.adamko.gradle.dev_publish.internal.DevPublishInternalApi
 import dev.adamko.gradle.dev_publish.utils.Attribute
-import org.gradle.api.Named
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.Usage
 import org.gradle.api.model.ObjectFactory
 import org.gradle.kotlin.dsl.named
@@ -18,17 +18,17 @@ import org.gradle.kotlin.dsl.named
 class DevPubAttributes(
   objects: ObjectFactory,
 ) {
-  @DevPublishInternalApi
-  interface DevPublishType : Named
-
   /** Indicates a [Configuration] contains a Maven Repository */
   val devPublishUsage: Usage = objects.named("dev-publish")
 
-  val mavenRepositoryType: DevPublishType = objects.named("maven-repository")
+  /** Indicates a [Configuration] contains a Maven Repository */
+  val devPublishCategory: Category = objects.named("dev-publish")
+
+  val mavenRepositoryType = "maven-repository"
 
   @DevPublishInternalApi
   companion object {
-    val DevPublishTypeAttribute: Attribute<DevPublishType> =
+    val DevPublishTypeAttribute: Attribute<String> =
       Attribute("dev.adamko.gradle.dev_publish.type")
   }
 }

--- a/src/main/kotlin/data/DevPubConfigurationsContainer.kt
+++ b/src/main/kotlin/data/DevPubConfigurationsContainer.kt
@@ -16,6 +16,7 @@ import org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE
 import org.gradle.api.model.ObjectFactory
 import org.gradle.kotlin.dsl.newInstance
 import javax.inject.Inject
+import org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE
 
 /**
  * Utility class that contains all [Configuration]s used by [dev.adamko.gradle.dev_publish.DevPublishPlugin].
@@ -50,6 +51,7 @@ abstract class DevPubConfigurationsContainer @Inject constructor(
       resolvable()
       attributes {
         attribute(USAGE_ATTRIBUTE, devPubAttributes.devPublishUsage)
+        attribute(CATEGORY_ATTRIBUTE, devPubAttributes.devPublishCategory)
         attribute(DevPublishTypeAttribute, devPubAttributes.mavenRepositoryType)
       }
       extendsFrom(testMavenPublicationDependencies.get())
@@ -61,6 +63,7 @@ abstract class DevPubConfigurationsContainer @Inject constructor(
       consumable()
       attributes {
         attribute(USAGE_ATTRIBUTE, devPubAttributes.devPublishUsage)
+        attribute(CATEGORY_ATTRIBUTE, devPubAttributes.devPublishCategory)
         attribute(DevPublishTypeAttribute, devPubAttributes.mavenRepositoryType)
       }
       extendsFrom(testMavenPublicationDependencies.get())


### PR DESCRIPTION
- Remote typesafe attribute - they are bugged https://github.com/gradle/gradle/issues/28695
- Add Category attribute (apparently it's better than Usage? Although there's no explanation for this gradle/gradle#27991 (comment))