### PR TITLE
Convert helper classes from managed types to actual classes

### DIFF
--- a/src/main/kotlin/DevPublishPlugin.kt
+++ b/src/main/kotlin/DevPublishPlugin.kt
@@ -1,6 +1,7 @@
 package dev.adamko.gradle.dev_publish
 
-import dev.adamko.gradle.dev_publish.data.DevPubConfigurationsContainer.Companion.newDevPubConfigurationsContainer
+import dev.adamko.gradle.dev_publish.data.DevPubAttributes
+import dev.adamko.gradle.dev_publish.data.DevPubConfigurationsContainer
 import dev.adamko.gradle.dev_publish.internal.DevPublishInternalApi
 import dev.adamko.gradle.dev_publish.services.DevPublishService
 import dev.adamko.gradle.dev_publish.services.DevPublishService.Companion.SERVICE_NAME
@@ -49,15 +50,18 @@ constructor(
 
     val devPubService = project.gradle.sharedServices.registerDevPubService()
 
-    val devPubTasks: DevPublishTasksContainer = objects.newInstance(
-      project.tasks,
-      devPubExtension,
+    val devPubTasks = DevPublishTasksContainer(
+      tasks = project.tasks,
+      devPubExtension = devPubExtension,
+      objects = objects,
     )
 
-    val devPubConfigurations = objects.newDevPubConfigurationsContainer(
+    val devPubAttributes = DevPubAttributes(objects)
+
+    val devPubConfigurations = DevPubConfigurationsContainer(
+      devPubAttributes = devPubAttributes,
       dependencies = project.dependencies,
       configurations = project.configurations,
-      objects = objects,
     )
 
     devPubTasks.updateDevRepo.configure {

--- a/src/main/kotlin/data/DevPubConfigurationsContainer.kt
+++ b/src/main/kotlin/data/DevPubConfigurationsContainer.kt
@@ -12,23 +12,18 @@ import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.dsl.DependencyHandler
-import org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE
-import org.gradle.api.model.ObjectFactory
-import org.gradle.kotlin.dsl.newInstance
-import javax.inject.Inject
 import org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE
+import org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE
 
 /**
  * Utility class that contains all [Configuration]s used by [dev.adamko.gradle.dev_publish.DevPublishPlugin].
  */
 @DevPublishInternalApi
-abstract class DevPubConfigurationsContainer @Inject constructor(
+class DevPubConfigurationsContainer(
+  private val devPubAttributes: DevPubAttributes,
   dependencies: DependencyHandler,
   configurations: ConfigurationContainer,
-  objects: ObjectFactory,
 ) {
-
-  private val devPubAttributes = DevPubAttributes(objects)
 
   init {
     // register the attribute for consuming/providing
@@ -70,17 +65,5 @@ abstract class DevPubConfigurationsContainer @Inject constructor(
     }
 
   @DevPublishInternalApi
-  companion object {
-    internal fun ObjectFactory.newDevPubConfigurationsContainer(
-      dependencies: DependencyHandler,
-      configurations: ConfigurationContainer,
-      objects: ObjectFactory,
-    ): DevPubConfigurationsContainer {
-      return newInstance<DevPubConfigurationsContainer>(
-        dependencies,
-        configurations,
-        objects,
-      )
-    }
-  }
+  companion object
 }

--- a/src/main/kotlin/tasks/DevPublishTasksContainer.kt
+++ b/src/main/kotlin/tasks/DevPublishTasksContainer.kt
@@ -7,11 +7,10 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
-import javax.inject.Inject
 
 /** Container for all [dev.adamko.gradle.dev_publish.DevPublishPlugin] tasks. */
 @DevPublishInternalApi
-abstract class DevPublishTasksContainer @Inject constructor(
+class DevPublishTasksContainer(
   tasks: TaskContainer,
   devPubExtension: DevPublishPluginExtension,
   private val objects: ObjectFactory,

--- a/src/main/kotlin/tasks/GeneratePublicationDataChecksumTask.kt
+++ b/src/main/kotlin/tasks/GeneratePublicationDataChecksumTask.kt
@@ -2,15 +2,15 @@ package dev.adamko.gradle.dev_publish.tasks
 
 import dev.adamko.gradle.dev_publish.data.PublicationData
 import dev.adamko.gradle.dev_publish.internal.DevPublishInternalApi
-import dev.adamko.gradle.dev_publish.services.DevPublishService
+import javax.inject.Inject
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileSystemOperations
-import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.LocalState
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
-import javax.inject.Inject
 
 
 @DisableCachingByDefault


### PR DESCRIPTION
There's not really any need for the classes to be managed types. It's easier/cleaner to just manually construct them.