### PR TITLE
Disable task caching

### DIFF
--- a/src/main/kotlin/tasks/BaseDevPublishTask.kt
+++ b/src/main/kotlin/tasks/BaseDevPublishTask.kt
@@ -5,7 +5,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.work.DisableCachingByDefault
 
 /** Base task type for all [dev.adamko.gradle.dev_publish.DevPublishPlugin] tasks. */
-@DisableCachingByDefault
+@DisableCachingByDefault(because = "Lifecycle task")
 abstract class BaseDevPublishTask
 @DevPublishInternalApi constructor() : DefaultTask() {
   init {

--- a/src/main/kotlin/tasks/GeneratePublicationDataChecksumTask.kt
+++ b/src/main/kotlin/tasks/GeneratePublicationDataChecksumTask.kt
@@ -17,7 +17,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
 
-@DisableCachingByDefault
+@DisableCachingByDefault(because = "Always re-compute checksums")
 abstract class GeneratePublicationDataChecksumTask
 @Inject
 @DevPublishInternalApi

--- a/src/main/kotlin/tasks/UpdateDevRepoTask.kt
+++ b/src/main/kotlin/tasks/UpdateDevRepoTask.kt
@@ -12,8 +12,9 @@ import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
+import org.gradle.work.DisableCachingByDefault
 
-@CacheableTask
+@DisableCachingByDefault(because = "This task only relocates files")
 abstract class UpdateDevRepoTask
 @Inject
 @DevPublishInternalApi

--- a/src/test/kotlin/BuildCacheTest.kt
+++ b/src/test/kotlin/BuildCacheTest.kt
@@ -1,0 +1,123 @@
+package dev.adamko.gradle.dev_publish
+
+import dev.adamko.gradle.dev_publish.test_utils.*
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestScope
+import io.kotest.matchers.paths.shouldBeADirectory
+import io.kotest.matchers.shouldBe
+import java.nio.file.Path
+import kotlin.io.path.*
+
+@OptIn(ExperimentalPathApi::class)
+class BuildCacheTest : FunSpec({
+
+  context("test single-module project") {
+    val project = project()
+
+    val expectedBuildCacheDir = project.projectDir.resolve("local-cache")
+    expectedBuildCacheDir.deleteRecursively()
+
+    project.runner
+      //.forwardOutput()
+      .withArguments(
+        ":build",
+        "--stacktrace",
+        "--configuration-cache",
+        "--build-cache",
+        //"-Dorg.gradle.caching.debug=true",
+        "--rerun-tasks",
+      ).build {
+
+        test("can build") {
+          expectedBuildCacheDir.shouldBeADirectory()
+
+          shouldHaveRunTask(":compileKotlin")
+          shouldHaveRunTask(":compileTestKotlin")
+
+          shouldNotHaveRunTask(":publishMavenJavaPublicationToDevPublishMavenRepository")
+          shouldNotHaveRunTask(":publishAllPublicationsToDevPublishMavenRepository")
+          shouldNotHaveRunTask(":updateDevRepo")
+        }
+
+        val initialBuildCacheSize =
+          expectedBuildCacheDir.walk().filter { it.isRegularFile() }.map { it.fileSize() }.sum()
+
+        project.runner
+          //.forwardOutput()
+          .withArguments(
+            ":updateDevRepo",
+            "--stacktrace",
+            "--configuration-cache",
+            "--build-cache",
+            //"-Dorg.gradle.caching.debug=true",
+          ).build {
+
+            test("build cache should be same size") {
+              shouldHaveRunTask(":publishMavenJavaPublicationToDevPublishMavenRepository")
+              shouldHaveRunTask(":publishAllPublicationsToDevPublishMavenRepository")
+              shouldHaveRunTask(":updateDevRepo")
+            }
+
+            test("Build cache size should be the same") {
+              expectedBuildCacheDir.shouldBeADirectory()
+
+              val buildCacheSizeAfterDevPublish = expectedBuildCacheDir.recursiveFileSize()
+
+              withClue("before: $initialBuildCacheSize, after: $buildCacheSizeAfterDevPublish") {
+                buildCacheSizeAfterDevPublish shouldBe initialBuildCacheSize
+              }
+            }
+          }
+      }
+  }
+}) {
+
+  companion object {
+    private fun Path.recursiveFileSize(): Long =
+      walk().filter { it.isRegularFile() }.map { it.fileSize() }.sum()
+
+    private fun TestScope.project(): GradleProjectTest =
+      gradleKtsProjectTest(
+        projectName = "build-cache",
+        testProjectPath = testCase.descriptor.slashSeparatedPath(),
+      ) {
+
+        buildGradleKts = """
+            plugins {
+              kotlin("jvm") version embeddedKotlinVersion
+              id("dev.adamko.dev-publish") version "+"
+              `maven-publish`
+            }
+            
+            group = "foo.project"
+            version = "0.0.1"
+            
+            publishing {
+              publications {
+                create<MavenPublication>("mavenJava") {
+                  from(components["java"])
+                }
+              }
+            }
+        """.trimIndent()
+
+        settingsGradleKts += """
+          
+        buildCache {
+            local {
+                directory = file("local-cache").toURI()
+            }
+        }
+        """.trimIndent()
+
+        createKotlinFile(
+          "src/main/kotlin/FooClass.kt", """
+              class FooClass {
+                fun name() = "FooClass"
+              }
+            """.trimIndent()
+        )
+      }
+  }
+}

--- a/src/test/kotlin/MultiProjectTest.kt
+++ b/src/test/kotlin/MultiProjectTest.kt
@@ -77,7 +77,10 @@ class MultiProjectTest : FunSpec({
   companion object {
 
     private fun TestScope.project(): GradleProjectTest =
-      gradleKtsProjectTest(testCase.name.testName.replaceNonAlphaNumeric()) {
+      gradleKtsProjectTest(
+        projectName = "multi-module project",
+        testProjectPath = testCase.descriptor.slashSeparatedPath(),
+      ) {
 
         settingsGradleKts += """
           include(

--- a/src/test/kotlin/MultipleGradlePluginsTest.kt
+++ b/src/test/kotlin/MultipleGradlePluginsTest.kt
@@ -2,6 +2,7 @@ package dev.adamko.gradle.dev_publish
 
 import dev.adamko.gradle.dev_publish.test_utils.*
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestScope
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import java.nio.file.Path
@@ -10,7 +11,7 @@ import org.intellij.lang.annotations.Subst
 
 class MultipleGradlePluginsTest : FunSpec({
 
-  context("test multiple Gradle plugins") {
+  context("multiple Gradle plugins") {
     val project = project()
 
     test("clean should succeed") {
@@ -252,76 +253,83 @@ private fun Path.shouldBeMavenDevRepoWithPlugins(
   }
 }
 
-private fun project(): GradleProjectTest = gradleKtsProjectTest("multiple-gradle-plugins") {
+private fun TestScope.project(): GradleProjectTest =
+  gradleKtsProjectTest(
+    projectName = "multiple-gradle-plugins",
+    testProjectPath = testCase.descriptor.slashSeparatedPath(),
+  ) {
 
-  buildGradleKts = """
-    plugins {
-      `embedded-kotlin`
-      `java-gradle-plugin`
-      `maven-publish`
-      id("dev.adamko.dev-publish") version "+"
-    }
-    
-    group = "dev.publish.plugin.test"
-    version = "1.2.3"
-    
-    gradlePlugin {
-      isAutomatedPublishing = true
-    
-      plugins.register("alpha") {
-        id = "plugin-alpha"
-        displayName = "PluginAlpha"
-        implementationClass = "PluginAlpha"
+    buildGradleKts = """
+      plugins {
+        `embedded-kotlin`
+        `java-gradle-plugin`
+        `maven-publish`
+        id("dev.adamko.dev-publish") version "+"
       }
-      plugins.register("beta") {
-        id = "plugin-beta"
-        displayName = "PluginBeta"
-        implementationClass = "PluginBeta"
+      
+      group = "dev.publish.plugin.test"
+      version = "1.2.3"
+      
+      gradlePlugin {
+        isAutomatedPublishing = true
+      
+        plugins.register("alpha") {
+          id = "plugin-alpha"
+          displayName = "PluginAlpha"
+          implementationClass = "PluginAlpha"
+        }
+        plugins.register("beta") {
+          id = "plugin-beta"
+          displayName = "PluginBeta"
+          implementationClass = "PluginBeta"
+        }
+        plugins.register("gamma") {
+          id = "plugin-gamma"
+          displayName = "PluginGamma"
+          implementationClass = "PluginGamma"
+        }
       }
-      plugins.register("gamma") {
-        id = "plugin-gamma"
-        displayName = "PluginGamma"
-        implementationClass = "PluginGamma"
-      }
-    }
-  """.trimIndent()
+    """.trimIndent()
 
-  dir("src/main/kotlin") {
-    createKotlinFile(
-      "PluginAlpha.kt", """
-        import org.gradle.api.*   
-        
-        class PluginAlpha : Plugin<Project> {
-          override fun apply(project: Project) {
-            println("plugin-alpha")
+    dir("src/main/kotlin") {
+      createKotlinFile(
+        "PluginAlpha.kt",
+        """
+          import org.gradle.api.*   
+          
+          class PluginAlpha : Plugin<Project> {
+            override fun apply(project: Project) {
+              println("plugin-alpha")
+            }
           }
-        }
-      """.trimIndent()
-    )
-    createKotlinFile(
-      "PluginBeta.kt", """
-        import org.gradle.api.*   
-        
-        class PluginBeta : Plugin<Project> {
-          override fun apply(project: Project) {
-            println("plugin-beta")
+        """.trimIndent()
+      )
+      createKotlinFile(
+        "PluginBeta.kt",
+        """
+          import org.gradle.api.*   
+          
+          class PluginBeta : Plugin<Project> {
+            override fun apply(project: Project) {
+              println("plugin-beta")
+            }
           }
-        }
-      """.trimIndent()
-    )
-    createKotlinFile(
-      "PluginGamma.kt", """
-        import org.gradle.api.*   
-        
-        class PluginGamma : Plugin<Project> {
-          override fun apply(project: Project) {
-            println("plugin-gamma")
+        """.trimIndent()
+      )
+      createKotlinFile(
+        "PluginGamma.kt",
+        """
+          import org.gradle.api.*   
+          
+          class PluginGamma : Plugin<Project> {
+            override fun apply(project: Project) {
+              println("plugin-gamma")
+            }
           }
-        }
-      """.trimIndent()
-    )
+        """.trimIndent()
+      )
+    }
   }
-}
 
 
 private fun GradleProjectTest.updateVersion(version: String) {

--- a/src/test/kotlin/SingleProjectTest.kt
+++ b/src/test/kotlin/SingleProjectTest.kt
@@ -43,7 +43,10 @@ class SingleProjectTest : FunSpec({
   companion object {
 
     private fun TestScope.project(): GradleProjectTest =
-      gradleKtsProjectTest(testCase.name.testName.replaceNonAlphaNumeric()) {
+      gradleKtsProjectTest(
+        projectName = "single-module-project",
+        testProjectPath = testCase.descriptor.slashSeparatedPath(),
+      ) {
 
         buildGradleKts = """
             plugins {
@@ -74,23 +77,23 @@ class SingleProjectTest : FunSpec({
       maven-dev/
       └── foo/
           └── project/
-              └── test-single-module-project/
+              └── single-module-project/
                   ├── 0.0.1/
-                  │   ├── test-single-module-project-0.0.1.jar
-                  │   ├── test-single-module-project-0.0.1.jar.md5
-                  │   ├── test-single-module-project-0.0.1.jar.sha1
-                  │   ├── test-single-module-project-0.0.1.jar.sha256
-                  │   ├── test-single-module-project-0.0.1.jar.sha512
-                  │   ├── test-single-module-project-0.0.1.module
-                  │   ├── test-single-module-project-0.0.1.module.md5
-                  │   ├── test-single-module-project-0.0.1.module.sha1
-                  │   ├── test-single-module-project-0.0.1.module.sha256
-                  │   ├── test-single-module-project-0.0.1.module.sha512
-                  │   ├── test-single-module-project-0.0.1.pom
-                  │   ├── test-single-module-project-0.0.1.pom.md5
-                  │   ├── test-single-module-project-0.0.1.pom.sha1
-                  │   ├── test-single-module-project-0.0.1.pom.sha256
-                  │   └── test-single-module-project-0.0.1.pom.sha512
+                  │   ├── single-module-project-0.0.1.jar
+                  │   ├── single-module-project-0.0.1.jar.md5
+                  │   ├── single-module-project-0.0.1.jar.sha1
+                  │   ├── single-module-project-0.0.1.jar.sha256
+                  │   ├── single-module-project-0.0.1.jar.sha512
+                  │   ├── single-module-project-0.0.1.module
+                  │   ├── single-module-project-0.0.1.module.md5
+                  │   ├── single-module-project-0.0.1.module.sha1
+                  │   ├── single-module-project-0.0.1.module.sha256
+                  │   ├── single-module-project-0.0.1.module.sha512
+                  │   ├── single-module-project-0.0.1.pom
+                  │   ├── single-module-project-0.0.1.pom.md5
+                  │   ├── single-module-project-0.0.1.pom.sha1
+                  │   ├── single-module-project-0.0.1.pom.sha256
+                  │   └── single-module-project-0.0.1.pom.sha512
                   ├── maven-metadata.xml
                   ├── maven-metadata.xml.md5
                   ├── maven-metadata.xml.sha1

--- a/src/testFixtures/kotlin/GradleTestKitUtils.kt
+++ b/src/testFixtures/kotlin/GradleTestKitUtils.kt
@@ -1,8 +1,6 @@
 package dev.adamko.gradle.dev_publish.test_utils
 
 import dev.adamko.gradle.dev_publish.test_utils.GradleProjectTest.Companion.testMavenRepoPathString
-import org.gradle.testkit.runner.GradleRunner
-import org.intellij.lang.annotations.Language
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -10,6 +8,8 @@ import kotlin.io.path.name
 import kotlin.properties.PropertyDelegateProvider
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
+import org.gradle.testkit.runner.GradleRunner
+import org.intellij.lang.annotations.Language
 
 
 // utils for testing using Gradle TestKit
@@ -17,17 +17,20 @@ import kotlin.reflect.KProperty
 
 class GradleProjectTest(
   override val projectDir: Path,
+  val projectName: String = projectDir.name.lowercase(),
 ) : ProjectDirectoryScope {
 
   constructor(
-    testProjectName: String,
+    testProjectPath: String,
     baseDir: Path = funcTestTempDir,
-  ) : this(projectDir = baseDir.resolve(testProjectName))
+    projectName: String,
+  ) : this(
+    projectDir = baseDir.resolve(testProjectPath),
+    projectName = projectName,
+  )
 
   val runner: GradleRunner = GradleRunner.create()
     .withProjectDir(projectDir.toFile())
-
-  val projectName by projectDir::name
 
   companion object {
 
@@ -55,17 +58,22 @@ class GradleProjectTest(
  * Builder for testing a Gradle project that uses Kotlin script DSL and creates default
  * `settings.gradle.kts` and `gradle.properties` files.
  *
- * @param[testProjectName] the path of the project directory
+ * @param[testProjectPath] the path of the project directory, relative to [baseDir].
  */
 fun gradleKtsProjectTest(
-  testProjectName: String,
+  projectName: String,
+  testProjectPath: String,
   baseDir: Path = GradleProjectTest.funcTestTempDir,
   build: GradleProjectTest.() -> Unit,
 ): GradleProjectTest {
-  return GradleProjectTest(baseDir = baseDir, testProjectName = testProjectName).apply {
+  return GradleProjectTest(
+    baseDir = baseDir,
+    testProjectPath = testProjectPath,
+    projectName = projectName,
+  ).apply {
 
     settingsGradleKts = """
-      |rootProject.name = "$projectName"
+      |rootProject.name = "${this.projectName}"
       |
       |pluginManagement {
       |  repositories {

--- a/src/testFixtures/kotlin/kotestGradleAsserts.kt
+++ b/src/testFixtures/kotlin/kotestGradleAsserts.kt
@@ -85,17 +85,17 @@ private fun haveOutcome(outcome: TaskOutcome): Matcher<BuildTask?> =
 
 
 private fun haveAnyOutcome(outcomes: Collection<TaskOutcome>): Matcher<BuildTask?> {
-  val shouldHaveOutcome = when (outcomes.size) {
+  val haveOutcome = when (outcomes.size) {
     0 -> error("Must provide 1 or more expected task outcome, but received none")
-    1 -> "should have outcome ${outcomes.first().name}"
-    else -> "should have any outcome of ${outcomes.joinToString()}"
+    1 -> "have outcome ${outcomes.first().name}"
+    else -> "have any outcome of ${outcomes.joinToString()}"
   }
 
   return neverNullMatcher { value ->
     MatcherResult(
       value.outcome in outcomes,
-      { "Task ${value.path} $shouldHaveOutcome, but was ${value.outcome}" },
-      { "Task ${value.path} $shouldHaveOutcome, but was ${value.outcome}" },
+      { "Task ${value.path} should $haveOutcome, but was ${value.outcome}" },
+      { "Task ${value.path} should not $haveOutcome, but was ${value.outcome}" },
     )
   }
 }

--- a/src/testFixtures/kotlin/kotestUtils.kt
+++ b/src/testFixtures/kotlin/kotestUtils.kt
@@ -1,0 +1,13 @@
+package dev.adamko.gradle.dev_publish.test_utils
+
+import io.kotest.core.descriptors.Descriptor
+import io.kotest.core.descriptors.Descriptor.SpecDescriptor
+import io.kotest.core.descriptors.Descriptor.TestDescriptor
+
+// util for creating a distinct subdirectory for each test case
+tailrec fun Descriptor.slashSeparatedPath(suffix: String = ""): String {
+  return when (this) {
+    is SpecDescriptor -> id.value.removePrefix("dev.adamko.gradle.dev_publish.") + suffix
+    is TestDescriptor -> parent.slashSeparatedPath("/${id.value.replaceNonAlphaNumeric()}")
+  }
+}


### PR DESCRIPTION
Disable task caching for Dev Publish tasks.

Caching Dev Publish tasks is not useful, because they only relocate files, and do not do any computation, or should always be re-run (computing checksums for up-to-date checks).

Additional, refactor the test utils to make the tests more stable. (Use a distinct directory for each test project, and use a stable project-name.)